### PR TITLE
Syntax highlighting on GitHub & GitLab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.derw linguist-language=Elm
+*.derw gitlab-language=elm


### PR DESCRIPTION
https://github.com/github/linguist/blob/master/docs/overrides.md
https://docs.gitlab.com/ee/user/project/highlighting.html

Users on GitHub and GitLab platforms should be able to see `.derw` files with syntax highlighting using the `elm` syntax highlighter. This addresses the latest blog's beef with GitHub and also is an example for users on how to get their own syntax highlighting in the meantime until highlighting got merged upstream to Linguist and Rouge as well as finally trickling down to into GitHub and GitLab's dependencies respectively.