### PR TITLE
Various documentation/logging suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ $ git clone https://github.com/derw-lang/derw-syntax
 $ cp -r derw-syntax ~/.vscode/extensions/derw-syntax-0.0.1
 ```
 
-# VScode Language server
+# VSCode Language server
 
 ```console
 $ git clone https://github.com/derw-lang/derw-language-server

--- a/README.md
+++ b/README.md
@@ -556,4 +556,4 @@ $ cp -r derw-language-server ~/.vscode/extensions/derw-language-server-0.0.1
 
 # Name
 
-derw which means oak. Oak is one of the native trees in Wales, famous for it’s long life, tall stature, and hard, good quality wood. An English speaker might pronounce it as “deh-ru”.
+derw (/ˈdeːruː/, Welsh “oak”) is one of the native trees in Wales, famous for it’s long life, tall stature, and hard, good quality wood. An English speaker might pronounce it as “deh-ru”.

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Follow Derw on Twitter: https://twitter.com/derwlang
 
 # Install
 
-```bash
-npm install --save-dev derw
+```console
+$ npm install --save-dev derw
 ```
 
 or
 
-```bash
-npm install -g derw
+```console
+$ npm install -g derw
 ```
 
 # Usage
 
-```bash
-npx derw
+```console
+$ npx derw
 
 To get started:
 Start a package via `derw init`
@@ -32,10 +32,10 @@ Or find out info via `derw info`
 
 You can run the derw compiler via npx. You must provide files via `--files` or be in a package directory.
 
-```bash
-npx derw
+```console
+$ npx derw
 
-Let\'s write some Derw code
+Let’s write some Derw code
 To get started:
 Provide entry files via --files
 Or run me without args inside a package directory
@@ -184,7 +184,7 @@ asIs result =
         if animal.age == 1 of
             "Hello little one!"
         else
-            "You're old"
+            "You’re old"
     ```
 
 -   [x] Case..of
@@ -217,7 +217,7 @@ asIs result =
     sayHiTo name =
         case name of
             "Noah" -> "Hi " + name + !"
-            default: "I don't know you"
+            default: "I don’t know you"
     ```
 
 -   [x] List destructing
@@ -542,22 +542,18 @@ Currently VSCode syntax highlighting is supported by this extension: https://git
 
 Instead, you can do:
 
-```
-
-git clone https://github.com/derw-lang/derw-syntax
-cp -r derw-syntax ~/.vscode/extensions/derw-syntax-0.0.1
-
+```console
+$ git clone https://github.com/derw-lang/derw-syntax
+$ cp -r derw-syntax ~/.vscode/extensions/derw-syntax-0.0.1
 ```
 
 # VScode Language server
 
-```
-
-git clone https://github.com/derw-lang/derw-language-server
-cp -r derw-language-server ~/.vscode/extensions/derw-language-server-0.0.1
-
+```console
+$ git clone https://github.com/derw-lang/derw-language-server
+$ cp -r derw-language-server ~/.vscode/extensions/derw-language-server-0.0.1
 ```
 
 # Name
 
-derw which means oak. Oak is one of the native trees in Wales, famous for it's long life, tall stature, and hard, good quality wood. An English speaker might pronounce it as "deh-ru".
+derw which means oak. Oak is one of the native trees in Wales, famous for it’s long life, tall stature, and hard, good quality wood. An English speaker might pronounce it as “deh-ru”.

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -49,7 +49,7 @@ const compileParser = parser([
 ]);
 
 function showCompileHelp(): void {
-    console.log("Let's write some Derw code");
+    console.log("Let’s write some Derw code");
     console.log("To get started:");
     console.log("Initialize the current directory via `init`");
     console.log("Or provide entry files via `--files`");

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1418,7 +1418,7 @@ function parseEmptyList(tokens: Token[]): Result<string, EmptyList> {
     if (withoutWhitespace.length > 1) {
         return Err("Too many values for empty list.");
     } else if (withoutWhitespace.length === 0) {
-        return Err("Expected [] but didn't find one.");
+        return Err("Expected [] but didn’t find one.");
     }
 
     if (
@@ -2872,7 +2872,7 @@ ${block.lines.join("\n")}
             return Err(
                 `Not sure what the block starting on line ${
                     block.lineStart
-                } is. There's something wrong with the lines ${
+                } is. There’s something wrong with the lines ${
                     block.lineStart
                 } - ${block.lineStart + block.lines.length}:
 \`\`\`


### PR DESCRIPTION
I'm not a professional linguist, nor do I speak a lick of Welsh, however, I do have a bit of on understanding of IPA, and personally find it more direct to readers that *can* read IPA. This also makes it looking more *professional* with that Wikipedia vibe (whatever this means). Note on this though: `ˈ` is the stress marker and given the examples I read, it *seems* like it goes on the first syllable, but if not, the commit can easily be amended.

Most of this is subjectively better aesthetics though.

View rendered this README: https://github.com/toastal/derw/blob/xxxx/README.md